### PR TITLE
Properly support partially instantiated types

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+# v0.3.2
+
+## Bugfixes
++ `FieldView`s now work correctly with partially instantiated immutable types. Previous versions of FieldViews.jl could cause segfaulting behaviour in the presence of immutable structs with undefined fields.
+
 # v0.3.0
 
 ### Breaking Changes

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FieldViews"
 uuid = "ff5a1669-b1f2-423e-bbd7-b7fa0f7e0224"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Mason Protter <mason.protter@icloud.com>"]
 
 [workspace]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -85,10 +85,10 @@ Be aware that unlike StructArrays.jl, FieldViews.jl operates on the **fields** o
 Getting and setting to `FieldView` arrays is most efficient when the following are satisfied:
 
 1. The underlying array (e.g. `points`) satisfies the [`IsStrided`](@ref) trait
-2. The `eltype` of the array (e.g. `Point{Int}`) is concrete and immutable
-3. The type of the field (e.g. `x::Int`) is concrete and immutable
+2. The `eltype` of the array (e.g. `Point{Int}`) is concrete and not 'pointer-backed' (i.e. `Base.allocatedinline` should give `true`).
+3. The type of the field (e.g. `x::Int`) is concrete and an `isbitstype`.
 
-When all three of the above are satisfied, FieldViews can use efficient pointer methods to get and set fields in the array directly without needing to manipulate the entire struct.
+When all of the above conditions are satisfied, FieldViews can use efficient pointer methods to get and set fields in the array directly without needing to manipulate the entire struct.
 
 If any of the above conditions is *not* satisfied, then we need to fetch the entire struct,
 and then either return the requested field of the struct (`getindex`), or construct and store a version of the struct where the field has been modified (`setindex!`).  If the struct is a mutable type, `setindex!` expressions will call `setfield!` on the stored struct, otherwise we construct a new version of immutable structs where the requested field is modified (see  [Accessors.jl](https://github.com/JuliaObjects/Accessors.jl), and our custom [`FieldLens!!`](@ref) object).

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -538,3 +538,36 @@ end
         FieldView{:x, Any, 1, Any, Vector{Any}}
     )
 end
+
+@testset "Undef fields" begin
+    struct MaybeUndef
+        x::Int
+        y::Int
+        z::String
+        w::String
+        MaybeUndef() = new()
+        MaybeUndef(x) = new(x)
+        MaybeUndef(x, y) = new(x, y)
+        MaybeUndef(x, y, z) = new(x, y, z)
+        MaybeUndef(x, y, z, w) = new(x, y, z, w)
+    end
+    v = FieldViewable([
+        MaybeUndef()
+        MaybeUndef(1)
+        MaybeUndef(1, 2)
+        MaybeUndef(1, 2, "three")
+        MaybeUndef(1, 2, "three", "four")
+    ])
+    v.x[1] = 1
+    v.y[1] = 2
+    v.z[1] = "boo!"
+    v.w[1] = "this is okay because I already set z!"
+    @test v.x[1] == 1
+    @test v.y[1] == 2
+    @test v.z[1] == "boo!"
+    @test v.w[1] == "this is okay because I already set z!"
+
+    @test_throws Exception v.w[2] = "This is not okay because z isn't set!"
+    v.w[4] = "This is okay because z is set"
+    @test v.w[4] == "This is okay because z is set"
+end


### PR DESCRIPTION
Partially instantiated immutable types are *not* `allocatedinline`, they have some pointer indirection, so previous versions of FieldViews not only didn't properly support them, but could segfault if you hit the fast pointer path on them. 

e.g. before:
```julia
julia> struct MaybeUndef
            x::Int
            y::Int
            z::String
            w::String
            MaybeUndef() = new()
            MaybeUndef(x) = new(x)
            MaybeUndef(x, y) = new(x, y)
            MaybeUndef(x, y, z) = new(x, y, z)
            MaybeUndef(x, y, z, w) = new(x, y, z, w)
        end

julia> v = FieldViewable([
           MaybeUndef()
           MaybeUndef(1)
           MaybeUndef(1, 2)
           MaybeUndef(1, 2, "three")
           MaybeUndef(1, 2, "three", "four")
       ])
5-element FieldViewable{MaybeUndef, 1, Vector{MaybeUndef}}:
 MaybeUndef(2, 140460971892544, #undef, #undef)
 MaybeUndef(1, 140460971897872, #undef, #undef)
 MaybeUndef(1, 2, #undef, #undef)
 MaybeUndef(1, 2, "three", #undef)
 MaybeUndef(1, 2, "three", "four")

julia> v.z[1] = "hello"
ERROR: UndefRefError: access to undefined reference
Stacktrace:
 [1] macro expansion
   @ ~/.julia/packages/FieldViews/NrP3E/src/FieldViews.jl:623 [inlined]
 [2] setfield!!
   @ ~/.julia/packages/FieldViews/NrP3E/src/FieldViews.jl:623 [inlined]
 [3] set
   @ ~/.julia/packages/FieldViews/NrP3E/src/FieldViews.jl:620 [inlined]
 [4] setindex!(v::FieldView{:z, String, 1, MaybeUndef, Vector{MaybeUndef}}, x::String, inds::Int64)
   @ FieldViews ~/.julia/packages/FieldViews/NrP3E/src/FieldViews.jl:360
 [5] top-level scop
```
but this was even worse:
```julia

julia> v.x[1] = 1
1

julia> v
[77568] signal 11 (1): Segmentation fault
in expression starting at REPL[6]:1
gc_mark_objarray at /cache/build/builder-amdci5-2/julialang/julia-release-1-dot-12/src/gc-stock.c:1803
gc_mark_outrefs at /cache/build/builder-amdci5-2/julialang/julia-release-1-dot-12/src/gc-stock.c:2410 [inlined]
gc_mark_and_steal at /cache/build/builder-amdci5-2/julialang/julia-release-1-dot-12/src/gc-stock.c:2565
gc_mark_loop_parallel at /cache/build/builder-amdci5-2/julialang/julia-release-1-dot-12/src/gc-stock.c:2720 [inlined]
jl_parallel_gc_threadfun at /cache/build/builder-amdci5-2/julialang/julia-release-1-dot-12/src/gc-stock.c:3630
unknown function (ip: 0x7fc0456969ca) at /usr/lib/libc.so.6
unknown function (ip: 0x7fc04571aa0b) at /usr/lib/libc.so.6
Allocations: 29652044 (Pool: 29649798; Big: 2246); GC: 29
```

Both bad cases are now fixed in this version